### PR TITLE
Add import bookmarks from HTML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ SUBCOMMANDS:
     update    Update bookmark
     open      Open bookmark
     search    Search bookmark
+    import    Import bookmark
     help      Prints this message or the help of the given subcommand(s)
 ```
 
@@ -172,4 +173,12 @@ Search bookmarks that contains `rust` or `cli` in tag:
 
 ```
 $ bkm search -t rust cli
+```
+
+### `import`
+
+Import bookmarks from HTML file:
+
+```
+$ bkm import bookmarks.html
 ```

--- a/src/cmd/import.rs
+++ b/src/cmd/import.rs
@@ -1,9 +1,32 @@
 use clap::{App, ArgMatches, SubCommand};
 
+use database::DB;
+use utils::get_bookmarks_from_html;
+
 pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name("import")
         .about("Import bookmark")
+        .arg_from_usage("<FILE> 'Import bookmarks from html file'")
 }
 
 pub fn execute(args: &ArgMatches) {
+    let db = DB::open();
+    let file_name = args.value_of("FILE").unwrap();
+    let bookmarks = get_bookmarks_from_html(file_name);
+
+    for bookmark in bookmarks {
+        match db.add_bookmark(&bookmark.title, &bookmark.url) {
+            Ok(_) => {},
+            Err(e) => {
+                println!("{} for \"{}\"\n", e, &bookmark.url);
+                continue;
+            }
+        }
+
+        for tag in &bookmark.tags {
+            db.add_tag(bookmark.id, tag);
+        }
+
+        bookmark.print();
+    }
 }

--- a/src/cmd/import.rs
+++ b/src/cmd/import.rs
@@ -1,0 +1,9 @@
+use clap::{App, ArgMatches, SubCommand};
+
+pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
+    SubCommand::with_name("import")
+        .about("Import bookmark")
+}
+
+pub fn execute(args: &ArgMatches) {
+}

--- a/src/cmd/import.rs
+++ b/src/cmd/import.rs
@@ -1,4 +1,5 @@
 use clap::{App, ArgMatches, SubCommand};
+use std::path::Path;
 
 use database::DB;
 use utils::get_bookmarks_from_html;
@@ -11,8 +12,8 @@ pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
 
 pub fn execute(args: &ArgMatches) {
     let db = DB::open();
-    let file_name = args.value_of("FILE").unwrap();
-    let bookmarks = get_bookmarks_from_html(file_name);
+    let path = Path::new(args.value_of("FILE").unwrap());
+    let bookmarks = get_bookmarks_from_html(path.to_path_buf());
 
     for bookmark in bookmarks {
         match db.add_bookmark(&bookmark.title, &bookmark.url) {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -4,3 +4,4 @@ pub mod delete;
 pub mod update;
 pub mod open;
 pub mod search;
+pub mod import;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ fn main() {
         .subcommand(cmd::update::make_subcommand())
         .subcommand(cmd::open::make_subcommand())
         .subcommand(cmd::search::make_subcommand())
+        .subcommand(cmd::import::make_subcommand())
         .get_matches();
 
     match args.subcommand() {
@@ -37,6 +38,7 @@ fn main() {
         ("update", Some(args)) => cmd::update::execute(args),
         ("open", Some(args)) => cmd::open::execute(args),
         ("search", Some(args)) => cmd::search::execute(args),
+        ("import", Some(args)) => cmd::import::execute(args),
         _ => process::exit(1),
     }
 }

--- a/src/testdata/bookmarks.html
+++ b/src/testdata/bookmarks.html
@@ -1,0 +1,11 @@
+<DL><p>
+    <DT><H3 PERSONAL_TOOLBAR_FOLDER="true">Test</H3>
+    <DL><p>
+        <DT><H3>test</H3>
+        <DL><p>
+            <DT><A HREF="https://github.com" TAGS="Git,Hosting Service">GitHub</A>
+            <DT><A HREF="https://google.com">Google</A>
+        </DL><p>
+        <DT><A HREF="https://example.com">Example Domain</A>
+    </DL><p>
+</DL><p>

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,11 +3,12 @@ use select::document::Document;
 use select::predicate::Name;
 use std::fs::File;
 use std::io::BufReader;
+use std::path::PathBuf;
 
 use bookmark::Bookmark;
 
-pub fn get_bookmarks_from_html(file_name: &str) -> Vec<Bookmark> {
-    let file = File::open(file_name)
+pub fn get_bookmarks_from_html(path: PathBuf) -> Vec<Bookmark> {
+    let file = File::open(path)
         .expect("File not found or cannot be opened");
     let doc = Document::from_read(BufReader::new(&file)).unwrap();
     let mut bookmarks: Vec<Bookmark> = Vec::new();
@@ -46,4 +47,47 @@ pub fn get_title_from_url(url: &str) -> String {
     let doc = Document::from_read(res).unwrap();
 
     doc.find(Name("title")).next().unwrap().text()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::path::Path;
+
+    #[test]
+    fn test_get_bookmarks_from_html() {
+        let testdata: Vec<Bookmark> = vec![
+            (Bookmark {
+                id: 1,
+                title: "GitHub".to_string(),
+                url: "https://github.com".to_string(),
+                tags: vec!["Git".to_string(), "Hosting Service".to_string(), "test".to_string()],
+            }),
+            (Bookmark {
+                id: 2,
+                title: "Google".to_string(),
+                url: "https://google.com".to_string(),
+                tags: vec!["test".to_string()],
+            }),
+            (Bookmark {
+                id: 3,
+                title: "Example Domain".to_string(),
+                url: "https://example.com".to_string(),
+                tags: vec!["Test".to_string()],
+            }),
+        ];
+
+        let mut path = env::current_dir().unwrap();
+        path.push(Path::new(file!()).parent().unwrap());
+        path.push("testdata");
+        path.push("bookmarks.html");
+
+        let bookmarks: Vec<Bookmark> = get_bookmarks_from_html(path);
+
+        for (test_bookmark, bookmark) in testdata.iter().zip(bookmarks.iter()) {
+            assert_eq!((&test_bookmark.title, &test_bookmark.url, &test_bookmark.tags),
+                       (&bookmark.title, &bookmark.url, &bookmark.tags));
+        }
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,45 @@
 use reqwest;
 use select::document::Document;
 use select::predicate::Name;
+use std::fs::File;
+use std::io::BufReader;
+
+use bookmark::Bookmark;
+
+pub fn get_bookmarks_from_html(file_name: &str) -> Vec<Bookmark> {
+    let file = File::open(file_name)
+        .expect("File not found or cannot be opened");
+    let doc = Document::from_read(BufReader::new(&file)).unwrap();
+    let mut bookmarks: Vec<Bookmark> = Vec::new();
+
+    for (i, a) in doc.find(Name("a")).enumerate() {
+        let mut tags: Vec<String> = Vec::new();
+
+        if let Some(f) = a.parent().unwrap().parent().unwrap()
+            .parent().unwrap().find(Name("h3")).next() {
+            tags.push(f.text());
+        }
+
+        if let Some(t) = a.attr("tags") {
+            for tag in t.split(",") {
+                tags.push(tag.to_string());
+            }
+        }
+
+        tags.sort();
+        tags.dedup();
+
+        let bookmark = Bookmark::new(
+            (i + 1) as i64,
+            a.text(),
+            a.attr("href").unwrap().to_string(),
+            tags,
+        );
+        bookmarks.push(bookmark);
+    }
+
+    bookmarks
+}
 
 pub fn get_title_from_url(url: &str) -> String {
     let res = reqwest::get(url).expect("invalid URL");


### PR DESCRIPTION
This can support import bookmarks from many browsers.

Manually export bookmarks from browser to HTML file and run `$ bkm import ~/<FILE>`

Closes #1